### PR TITLE
 more consistent on destroy audit

### DIFF
--- a/lib/dm-is-audited/is/audited/resource.rb
+++ b/lib/dm-is-audited/is/audited/resource.rb
@@ -2,17 +2,17 @@ module DataMapper
   module Is
     module Audited
       module Resource
-        
+
         def changes
-          if @audited_original_attributes
-            @audited_original_attributes.merge(@audited_original_attributes) { |property, value|
-              [value, attribute_get(property.name)] if attribute_get(property.name) != value
-            }.delete_if {|k,v| v.nil?}
-          else
-            {}
-          end
+          @audited_attributes_changes
         end
-        
+
+        def update_attributes_changes(original_attributes, changed_attributes, audited_attribute_names)
+          @audited_attributes_changes = original_attributes
+            .select{|k, v| audited_attribute_names.include?(k) and changed_attributes[k] != v}
+            .map{|k, v| [ properties[k], [ v, changed_attributes[k] ] ]}
+            .to_h
+        end
       end
     end
   end


### PR DESCRIPTION
when model is destroyed, it's changes are no longer empty, but appear to be all set to `nil`. That makes audit logging flow consistent across all events. 
